### PR TITLE
Pytest 적용, Testing 로직 추가

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -228,6 +228,19 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "fake-useragent"
 version = "2.1.0"
 description = "Up-to-date simple useragent faker with real world database"
@@ -267,6 +280,18 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
+
+[[package]]
 name = "outcome"
 version = "1.3.0.post0"
 description = "Capture the outcome of Python function calls."
@@ -287,11 +312,27 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pycparser"
@@ -470,6 +511,27 @@ files = [
     {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
     {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
 ]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -689,4 +751,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "4f781e479bf529bb15142c274d663cab8d2a76c5027e403e617aba682f195d8a"
+content-hash = "095d5102d84380a1d29023148a28f72e4bb949d756b01d5f9539fa586538a214"

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,28 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
+    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 description = "Classes Without Boilerplate"
@@ -251,6 +273,27 @@ files = [
     {file = "fake_useragent-2.1.0-py3-none-any.whl", hash = "sha256:1363d8be4934627f80a84c21cce72d33c5da650a9f1fd7398520b1edb6ecd873"},
     {file = "fake_useragent-2.1.0.tar.gz", hash = "sha256:cbb2cde0512ecefec1e6175e59d8bcc5cd94af25161432860769a4f3767ad62c"},
 ]
+
+[[package]]
+name = "fastapi"
+version = "0.115.12"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d"},
+    {file = "fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.47.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "h11"
@@ -615,6 +658,24 @@ files = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.46.1"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227"},
+    {file = "starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
 name = "trio"
 version = "0.29.0"
 description = "A friendly Python library for async concurrency and I/O"
@@ -751,4 +812,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "095d5102d84380a1d29023148a28f72e4bb949d756b01d5f9539fa586538a214"
+content-hash = "c68e86c00761ccce790216a476683f90dfb288cfa09d10c1af0c29011e324d44"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,15 @@ dependencies = [
     "fake-useragent (>=2.1.0,<3.0.0)",
     "webdriver-manager (>=4.0.2,<5.0.0)",
     "pyshorteners (>=1.0.1,<2.0.0)",
-    "pydantic (>=2.11.2,<3.0.0)"
+    "pydantic (>=2.11.2,<3.0.0)",
+    "python-dotenv (>=1.1.0,<2.0.0)"
 ]
 
 [tool.poetry]
 package-mode = false
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.5"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "webdriver-manager (>=4.0.2,<5.0.0)",
     "pyshorteners (>=1.0.1,<2.0.0)",
     "pydantic (>=2.11.2,<3.0.0)",
-    "python-dotenv (>=1.1.0,<2.0.0)"
+    "python-dotenv (>=1.1.0,<2.0.0)",
+    "fastapi (>=0.115.12,<0.116.0)"
 ]
 
 [tool.poetry]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 pythonpath = .
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/test_ai_main.py
+++ b/tests/test_ai_main.py
@@ -1,0 +1,23 @@
+# AI_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# crawling_main이 실행되지 않도록 아예 가짜로 등록해버리기
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+# 이제 AI.main import해도 crawling_main이 실행되지 않음
+from AI.main import ai_today_notices
+
+@patch("AI.main.filter_date_notices")
+@patch("AI.main.crawling_notices")
+def test_ai_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "공지 제목", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = ai_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "공지 제목"

--- a/tests/test_aie_main.py
+++ b/tests/test_aie_main.py
@@ -1,0 +1,22 @@
+# AIE_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+# crawling_main 무력화
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from AIE.main import aie_today_notices
+
+@patch("AIE.main.filter_date_notices")
+@patch("AIE.main.crawling_notices")
+def test_aie_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "AIE 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = aie_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "AIE 공지"

--- a/tests/test_cbe_main.py
+++ b/tests/test_cbe_main.py
@@ -1,0 +1,22 @@
+# CBE_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+# crawling_main 무력화
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from CBE.main import cbe_today_notices
+
+@patch("CBE.main.filter_date_notices")
+@patch("CBE.main.crawling_notices")
+def test_cbe_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "CBE 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = cbe_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "CBE 공지"

--- a/tests/test_crawling_first.py
+++ b/tests/test_crawling_first.py
@@ -1,0 +1,52 @@
+# crawling_notices() 함수가 Selenium 객체들을 사용해 공지 정보를 추출하는 로직이 잘 작동하는지 mock 기반 검증 (외부 사이트 X)
+from unittest.mock import patch, MagicMock
+from crawling.crawling_first import crawling_notices
+
+@patch("crawling.crawling_first.webdriver.Chrome")
+@patch("crawling.crawling_first.counting_notices", return_value=2)
+@patch("crawling.crawling_first.making_xpath_list")
+def test_crawling_notices(mock_xpath_list, mock_count, mock_driver):
+    # 드라이버 & 요소들 목 객체 생성
+    mock_driver_instance = MagicMock()
+    mock_driver.return_value = mock_driver_instance
+
+    # XPath 리스트 반환
+    mock_xpath_list.return_value = [
+        {
+            "title": "/html/title",
+            "registered_date": "/html/date"
+        }
+    ]
+
+    # 날짜 요소 mock
+    el_date = MagicMock()
+    el_date.text = "2025.04.08"
+
+    # 제목 요소 mock
+    el_title = MagicMock()
+    el_title.text = "공지 제목"
+    el_title.get_attribute.return_value = "https://example.com"
+
+    # find_element가 특정 XPath로 불렸을 때 반환할 객체 지정
+    def find_element_mock(by, value):
+        if value == "/html/date":
+            return el_date
+        elif value == "/html/title":
+            return el_title
+        elif value == "/ul":
+            # 공지 리스트 부모 박스 mock
+            el_box = MagicMock()
+            el_box.find_elements.return_value = [MagicMock(), MagicMock()]  # dummy li 2개
+            return el_box
+        else:
+            return MagicMock()
+
+    mock_driver_instance.find_element.side_effect = find_element_mock
+
+    result = crawling_notices("http://example.com", "/ul", "li", "/a", "/span")
+
+    assert result == [{
+        "title": "공지 제목",
+        "date": "2025.04.08",
+        "link": "https://example.com"
+    }]

--- a/tests/test_crawling_main.py
+++ b/tests/test_crawling_main.py
@@ -1,0 +1,28 @@
+# crawling_main() 함수가 크롤링 함수가 리턴한 공지들을 잘 POST 요청하는지 검증
+
+import json
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+from crawling.crawling_main import crawling_main
+
+@patch("crawling.crawling_main.time.sleep", return_value=None)
+@patch("crawling.crawling_main.requests.post")
+@patch("builtins.open", new_callable=mock_open, read_data='[]')
+@patch("json.dump")
+def test_crawling_main_sends_new_notice(mock_dump, mock_open_file, mock_post, mock_sleep):
+    # POST 요청 성공하도록 mock
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_post.return_value = mock_response
+
+    # 공지 하나 리턴하는 mock 크롤링 함수
+    def fake_crawler():
+        raise KeyboardInterrupt  # 루프 빠져나오게
+
+    try:
+        crawling_main("data.json", "12345678", fake_crawler)
+    except KeyboardInterrupt:
+        pass
+
+    # POST 요청이 안 보내졌음을 확인 (데이터 없음이니까)
+    mock_post.assert_not_called()

--- a/tests/test_crawling_today.py
+++ b/tests/test_crawling_today.py
@@ -1,0 +1,14 @@
+# filter_date_notices() 함수가 특정 날짜에 등록된 공지들만 필터링하는 로직이 잘 작동하는지 검증
+
+from crawling.crawling_today import filter_date_notices
+
+def test_filter_date_notices_returns_today_only():
+    notices = [
+        {"title": "공지1", "date": "2025.04.08"},
+        {"title": "공지2", "date": "2025.04.07"},
+    ]
+
+    result = filter_date_notices(notices, "2025.04.08")
+
+    assert len(result) == 1
+    assert result[0]["title"] == "공지1"

--- a/tests/test_cse_main.py
+++ b/tests/test_cse_main.py
@@ -1,0 +1,21 @@
+# cse_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+from cse.main import cse_today_notices, Notice_Type
+
+# crawling_main 무력화
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+@patch("cse.main.filter_date_notices")
+@patch("cse.main.crawling_notices")
+def test_cse_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "CSE 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = cse_today_notices(Notice_Type.job)
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "CSE 공지"

--- a/tests/test_ee_main.py
+++ b/tests/test_ee_main.py
@@ -1,0 +1,21 @@
+# ee_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from EE.main import ee_today_notices
+
+@patch("EE.main.filter_date_notices")
+@patch("EE.main.crawling_notices")
+def test_ee_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "EE 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = ee_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "EE 공지"

--- a/tests/test_kor_main.py
+++ b/tests/test_kor_main.py
@@ -1,0 +1,21 @@
+# kor_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from kor.main import kor_today_notices
+
+@patch("kor.main.filter_date_notices")
+@patch("kor.main.crawling_notices")
+def test_kor_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "KOR 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = kor_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "KOR 공지"

--- a/tests/test_mec_main.py
+++ b/tests/test_mec_main.py
@@ -1,0 +1,22 @@
+# mec_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+# crawling_main 실행 방지
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from mec.main import mec_today_notices  # ✅ 함수명 정확하게
+
+@patch("mec.main.filter_date_notices")
+@patch("mec.main.crawling_notices")
+def test_mec_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "MEC 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = mec_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "MEC 공지"

--- a/tests/test_sse_main.py
+++ b/tests/test_sse_main.py
@@ -1,0 +1,21 @@
+# sse_main이 제대로 작동하는지 확인하기 위한 테스트
+
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.modules["crawling.crawling_main"] = MagicMock()
+
+from SSE.main import sse_today_notices
+
+@patch("SSE.main.filter_date_notices")
+@patch("SSE.main.crawling_notices")
+def test_sse_today_notices_filters_today(mock_crawling, mock_filter):
+    mock_crawling.return_value = [
+        {"title": "SSE 공지", "date": "2025.04.08", "link": "https://example.com"}
+    ]
+    mock_filter.return_value = [mock_crawling.return_value[0]]
+
+    result = sse_today_notices()
+
+    assert isinstance(result, list)
+    assert result[0]["title"] == "SSE 공지"


### PR DESCRIPTION
## PR 요약
`tests/` 디렉토리 내 @ena-isme, @SOSO-0304 가 작성한 모듈에 대한 테스트를 수행하는 파일 11개 추가

poetry 환경 내 루트 디렉토리 경로에서 `poetry run pytest` 명령어를 통해 테스트 수행 가능


**[File Tree]**
```
tests
    ├── test_ai_main.py
    ├── test_aie_main.py
    ├── test_cbe_main.py
    ├── test_crawling_first.py
    ├── test_crawling_main.py
    ├── test_crawling_today.py
    ├── test_cse_main.py
    ├── test_ee_main.py
    ├── test_kor_main.py
    ├── test_mec_main.py
    └── test_sse_main.py
```